### PR TITLE
Add unit tests for io.swagger.v3.oas.models.Paths and io.swagger.v3.oas.models.links.LinkParameter

### DIFF
--- a/modules/swagger-models/src/test/java/io/swagger/v3/oas/models/PathsTest.java
+++ b/modules/swagger-models/src/test/java/io/swagger/v3/oas/models/PathsTest.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright 2017 SmartBear Software
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.swagger.v3.oas.models;
+
+import java.util.HashMap;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class PathsTest {
+
+    @Test
+    public void testAddPathItem() {
+        Paths paths = new Paths();
+        Assert.assertEquals(paths.addPathItem("foo", null), paths);
+    }
+
+    @Test
+    public void testEquals() {
+        Paths paths = new Paths();
+        Assert.assertTrue(paths.equals(paths));
+        Assert.assertTrue(paths.equals(new Paths()));
+
+        Assert.assertFalse(paths.equals(null));
+        Assert.assertFalse(paths.equals(new String()));
+    }
+
+    @Test
+    public void testGetExtensions1() {
+        Paths paths = new Paths();
+        paths.addExtension("", null);
+        paths.addExtension("y-", null);
+        paths.addExtension(null, null);
+
+        Assert.assertNull(paths.getExtensions());
+    }
+
+    @Test
+    public void testGetExtensions2() {
+        Paths paths = new Paths();
+        paths.addExtension("x-", "foo");
+        paths.addExtension("x-", "bar");
+        paths.addExtension("x-", "baz");
+
+        Assert.assertEquals(paths.getExtensions(),
+                new HashMap<String, Object>() {{
+                    put("x-", "baz");
+                }});
+    }
+
+    @Test
+    public void testGetExtensions3() {
+        Paths paths = new Paths();
+        HashMap<String, Object> hashMap = new HashMap<>();
+        hashMap.put("x-", "foo");
+        hashMap.put("x-", "bar");
+        hashMap.put("x-", "baz");
+        paths.setExtensions(hashMap);
+
+        Assert.assertEquals(paths.getExtensions(),
+                new HashMap<String, Object>() {{
+                    put("x-", "baz");
+                }});
+    }
+
+    @Test
+    public void testExtensions() {
+        Paths paths = new Paths();
+        HashMap<String, Object> hashMap = new HashMap<>();
+        hashMap.put("x-", "foo");
+        hashMap.put("x-", "bar");
+        hashMap.put("x-", "baz");
+
+        Assert.assertEquals(paths.extensions(hashMap), paths);
+    }
+
+    @Test
+    public void testToString() {
+        Paths paths = new Paths();
+        paths.addPathItem("foo", null);
+        Assert.assertEquals(paths.toString(),
+                "class Paths {\n    {foo=null}\n}");
+    }
+}

--- a/modules/swagger-models/src/test/java/io/swagger/v3/oas/models/links/LinkParameterTest.java
+++ b/modules/swagger-models/src/test/java/io/swagger/v3/oas/models/links/LinkParameterTest.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright 2019 SmartBear Software
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.swagger.v3.oas.models.links;
+
+import java.util.HashMap;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class LinkParameterTest {
+
+    @Test
+    public void testValue() {
+        LinkParameter linkParameter = new LinkParameter();
+        linkParameter.setValue("foo");
+        linkParameter.setValue("bar");
+        linkParameter.setValue("baz");
+
+        Assert.assertEquals(linkParameter.value("bar"), linkParameter);
+        Assert.assertEquals(linkParameter.getValue(), "bar");
+    }
+
+    @Test
+    public void testEquals() {
+        LinkParameter linkParameter = new LinkParameter();
+        Assert.assertFalse(linkParameter.equals(null));
+        Assert.assertFalse(linkParameter.equals(new String()));
+
+        Assert.assertTrue(linkParameter.equals(linkParameter));
+        Assert.assertTrue(linkParameter.equals(new LinkParameter()));
+    }
+
+    @Test
+    public void testGetExtensions1() {
+        LinkParameter linkParameter = new LinkParameter();
+        linkParameter.addExtension("", null);
+        linkParameter.addExtension("y-", null);
+        linkParameter.addExtension(null, null);
+
+        Assert.assertNull(linkParameter.getExtensions());
+    }
+
+    @Test
+    public void testGetExtensions2() {
+        LinkParameter linkParameter = new LinkParameter();
+        linkParameter.addExtension("x-", "foo");
+        linkParameter.addExtension("x-", "bar");
+        linkParameter.addExtension("x-", "baz");
+
+        Assert.assertEquals(linkParameter.getExtensions(),
+                new HashMap<String, Object>() {{
+                    put("x-", "baz");
+                }});
+    }
+
+    @Test
+    public void testGetExtensions3() {
+        LinkParameter linkParameter = new LinkParameter();
+        HashMap<String, Object> hashMap = new HashMap<>();
+        hashMap.put("x-", "foo");
+        hashMap.put("x-", "bar");
+        hashMap.put("x-", "baz");
+        linkParameter.setExtensions(hashMap);
+
+        Assert.assertEquals(linkParameter.getExtensions(),
+                new HashMap<String, Object>() {{
+                    put("x-", "baz");
+                }});
+    }
+
+    @Test
+    public void testExtensions() {
+        LinkParameter linkParameter = new LinkParameter();
+        HashMap<String, Object> hashMap = new HashMap<>();
+        hashMap.put("x-", "foo");
+        hashMap.put("x-", "bar");
+        hashMap.put("x-", "baz");
+
+        Assert.assertEquals(linkParameter.extensions(hashMap), linkParameter);
+    }
+
+    @Test
+    public void testToString() {
+        LinkParameter linkParameter = new LinkParameter();
+        linkParameter.setValue("foo");
+        Assert.assertEquals(linkParameter.toString(),
+                "class LinkParameter {\n}");
+    }
+}


### PR DESCRIPTION
I've analysed your codebase and noticed that `io.swagger.v3.oas.models.Paths` and `io.swagger.v3.oas.models.links.LinkParameter` is not fully tested.
I've written some tests for the methods in this class with the help of [Diffblue Cover](https://www.diffblue.com/opensource).

Hopefully, these tests will help you detect any regressions caused by future code changes. If you would find it useful to have additional tests written for this repository, I would be more than happy to look at other classes that you consider important in a subsequent PR.